### PR TITLE
fix(dtoverlay_v4l2)[RDK-928]: Add stop_check_instart to skip CSI link…

### DIFF
--- a/debian/boot/overlays/dtoverlay_cam0_imx219.dts
+++ b/debian/boot/overlays/dtoverlay_cam0_imx219.dts
@@ -57,6 +57,7 @@
             data-lanes = <1 2>;
             lane-rate = <850>;
             vc_id = <0>;
+            stop_check_instart = <1>;
           };
         };
       };

--- a/debian/boot/overlays/dtoverlay_cam0_ov5647.dts
+++ b/debian/boot/overlays/dtoverlay_cam0_ov5647.dts
@@ -57,6 +57,7 @@
             data-lanes = <1 2>;
             lane-rate = <500>;
             vc_id = <0>;
+            stop_check_instart = <1>;
           };
         };
       };

--- a/debian/boot/overlays/dtoverlay_cam1_imx219.dts
+++ b/debian/boot/overlays/dtoverlay_cam1_imx219.dts
@@ -57,6 +57,7 @@
             data-lanes = <1 2>;
             lane-rate = <1000>;
             vc_id = <0>;
+            stop_check_instart = <1>;
           };
         };
       };

--- a/debian/boot/overlays/dtoverlay_cam1_ov5647.dts
+++ b/debian/boot/overlays/dtoverlay_cam1_ov5647.dts
@@ -57,6 +57,7 @@
             data-lanes = <1 2>;
             lane-rate = <500>;
             vc_id = <0>;
+            stop_check_instart = <1>;
           };
         };
       };


### PR DESCRIPTION
… detection during driver initialization